### PR TITLE
HTTP properties refactor

### DIFF
--- a/src/RokuDotNet.Client/DeviceDiscoveredEventArgs.cs
+++ b/src/RokuDotNet.Client/DeviceDiscoveredEventArgs.cs
@@ -2,21 +2,15 @@ using System;
 
 namespace RokuDotNet.Client
 {
-    public sealed class DeviceDiscoveredEventArgs : EventArgs
+    public class DeviceDiscoveredEventArgs : EventArgs
     {
-        public DeviceDiscoveredEventArgs(IRokuDevice device, Uri location, string serialNumber)
+        public DeviceDiscoveredEventArgs(DiscoveredDeviceContext context)
         {
-            this.Device = device ?? throw new ArgumentNullException(nameof(device));
-            this.Location = location ?? throw new ArgumentNullException(nameof(location));
-            this.SerialNumber = serialNumber ?? throw new ArgumentNullException(nameof(serialNumber));
+            this.Context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
         public bool CancelDiscovery { get; set; }
 
-        public IRokuDevice Device { get; }
-
-        public Uri Location { get; }
-
-        public string SerialNumber { get; }
+        public DiscoveredDeviceContext Context { get; }
     }
 }

--- a/src/RokuDotNet.Client/DiscoveredDeviceContext.cs
+++ b/src/RokuDotNet.Client/DiscoveredDeviceContext.cs
@@ -2,18 +2,15 @@ using System;
 
 namespace RokuDotNet.Client
 {
-    public sealed class DiscoveredDeviceContext
+    public class DiscoveredDeviceContext
     {
-        public DiscoveredDeviceContext(IRokuDevice device, Uri location, string serialNumber)
+        public DiscoveredDeviceContext(IRokuDevice device, string serialNumber)
         {
             this.Device = device ?? throw new ArgumentNullException(nameof(device));
-            this.Location = location ?? throw new ArgumentNullException(nameof(location));
             this.SerialNumber = serialNumber ?? throw new ArgumentNullException(nameof(serialNumber));
         }
 
         public IRokuDevice Device { get; }
-
-        public Uri Location { get; }
 
         public string SerialNumber { get; }
     }

--- a/src/RokuDotNet.Client/HttpDeviceDiscoveredEventArgs.cs
+++ b/src/RokuDotNet.Client/HttpDeviceDiscoveredEventArgs.cs
@@ -1,0 +1,13 @@
+namespace RokuDotNet.Client
+{
+    public sealed class HttpDeviceDiscoveredEventArgs : DeviceDiscoveredEventArgs
+    {
+        public HttpDeviceDiscoveredEventArgs(HttpDiscoveredDeviceContext context)
+            : base(context)
+        {
+            this.Context = context;
+        }
+
+        public new HttpDiscoveredDeviceContext Context { get; }
+    }
+}

--- a/src/RokuDotNet.Client/HttpDiscoveredDeviceContext.cs
+++ b/src/RokuDotNet.Client/HttpDiscoveredDeviceContext.cs
@@ -1,0 +1,13 @@
+namespace RokuDotNet.Client
+{
+    public sealed class HttpDiscoveredDeviceContext : DiscoveredDeviceContext
+    {
+        public HttpDiscoveredDeviceContext(IHttpRokuDevice device, string serialNumber)
+            : base(device, serialNumber)
+        {
+            this.Device = device;
+        }
+
+        public new IHttpRokuDevice Device { get; }
+    }
+}

--- a/src/RokuDotNet.Client/HttpRokuDevice.cs
+++ b/src/RokuDotNet.Client/HttpRokuDevice.cs
@@ -11,14 +11,16 @@ using RokuDotNet.Client.Query;
 
 namespace RokuDotNet.Client
 {
-    public sealed class RokuDevice : IRokuDevice, IRokuDeviceInput, IRokuDeviceQuery
+    public sealed class HttpRokuDevice : IRokuDevice, IRokuDeviceInput, IRokuDeviceQuery
     {
-        private readonly HttpClient client = new HttpClient();
+        private readonly HttpClient client;
 
-        public RokuDevice(Uri location, string id)
+        public HttpRokuDevice(string id, Uri location, HttpMessageHandler handler = null)
         {
-            this.Location = location ?? throw new ArgumentNullException(nameof(location));
             this.Id = id ?? throw new ArgumentNullException(nameof(id));
+            this.Location = location ?? throw new ArgumentNullException(nameof(location));
+
+            this.client = handler != null ? new HttpClient(handler) : new HttpClient();
         }
 
         public Uri Location { get; }
@@ -92,6 +94,15 @@ namespace RokuDotNet.Client
         Task<GetTvChannelsResult> IRokuDeviceQuery.GetTvChannelsAsync(CancellationToken cancellationToken)
         {
             return this.GetAsync<GetTvChannelsResult>("query/tv-channels");
+        }
+
+        #endregion
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            this.client.Dispose();
         }
 
         #endregion

--- a/src/RokuDotNet.Client/HttpRokuDevice.cs
+++ b/src/RokuDotNet.Client/HttpRokuDevice.cs
@@ -11,7 +11,7 @@ using RokuDotNet.Client.Query;
 
 namespace RokuDotNet.Client
 {
-    public sealed class HttpRokuDevice : IRokuDevice, IRokuDeviceInput, IRokuDeviceQuery
+    public sealed class HttpRokuDevice : IHttpRokuDevice, IRokuDeviceInput, IRokuDeviceQuery
     {
         private readonly HttpClient client;
 
@@ -23,7 +23,11 @@ namespace RokuDotNet.Client
             this.client = handler != null ? new HttpClient(handler) : new HttpClient();
         }
 
+        #region IHttpRokuDevice Members
+
         public Uri Location { get; }
+
+        #endregion
 
         #region IRokuDevice Members
 

--- a/src/RokuDotNet.Client/IHttpRokuDevice.cs
+++ b/src/RokuDotNet.Client/IHttpRokuDevice.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace RokuDotNet.Client
+{
+    public interface IHttpRokuDevice : IRokuDevice
+    {
+        Uri Location { get; }
+    }
+}

--- a/src/RokuDotNet.Client/IRokuDevice.cs
+++ b/src/RokuDotNet.Client/IRokuDevice.cs
@@ -4,7 +4,7 @@ using RokuDotNet.Client.Query;
 
 namespace RokuDotNet.Client
 {
-    public interface IRokuDevice
+    public interface IRokuDevice : IDisposable
     {
         string Id { get; }
 

--- a/src/RokuDotNet.Client/RokuDotNet.Client.csproj
+++ b/src/RokuDotNet.Client/RokuDotNet.Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">0.3</AssemblyVersion>
+    <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">0.4</AssemblyVersion>
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(AssemblyVersion).0</PackageVersion>
     <AssemblyFileVersion Condition="'$(AssemblyFileVersion)' == ''">$(PackageVersion)</AssemblyFileVersion>
   </PropertyGroup>

--- a/src/RokuDotNet.Client/UdpRokuDeviceDiscoveryClient.cs
+++ b/src/RokuDotNet.Client/UdpRokuDeviceDiscoveryClient.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace RokuDotNet.Client
 {
-    public sealed class RokuDeviceDiscoveryClient : IRokuDeviceDiscoveryClient
+    public sealed class UdpRokuDeviceDiscoveryClient : IRokuDeviceDiscoveryClient
     {
         #region IRokuDeviceDiscoveryClient Members
 
@@ -77,7 +77,7 @@ namespace RokuDotNet.Client
                         && Uri.TryCreate(location, UriKind.Absolute, out Uri locationUri)
                         && response.Headers.TryGetValue("USN", out string serialNumber))
                     {
-                        var device = new RokuDevice(locationUri, serialNumber);
+                        var device = new HttpRokuDevice(serialNumber, locationUri);
 
                         bool cancelDiscovery = false;
 


### PR DESCRIPTION
Further isolate the HTTP properties (e.g. `Location`) from the base device and discovery interfaces.